### PR TITLE
keys: Add missing /etc/ceph mount to write keys to the host

### DIFF
--- a/plugins/modules/cephadm_key.py
+++ b/plugins/modules/cephadm_key.py
@@ -197,6 +197,8 @@ def generate_ceph_authtool_cmd(name, secret, caps, dest):  # noqa: E501
         '--timeout',
         '30',
         'shell',
+        '--mount',
+        '/etc/ceph:/etc/ceph',
         '--',
         'ceph-authtool',
         '--create-keyring',


### PR DESCRIPTION
cephadm itself does not implicitly mount /etc/ceph and instead mounts
the ceph.client.admin.keyring directly. This means when creating keys
using `cephadm shell -- ceph auth ...` they are not actually being
written to the host and are lost once the container exits.